### PR TITLE
Fix text cut off on high DPI screens

### DIFF
--- a/index.py
+++ b/index.py
@@ -10,6 +10,7 @@ from PyQt5.QtGui import (
     QDesktopServices,
 )
 from PyQt5.QtCore import (
+    Qt,
     QUrl
 )
 from PyQt5 import uic
@@ -17,6 +18,15 @@ import sys
 import core
 import os
 
+if hasattr(Qt, 'AA_EnableHighDpiScaling'):
+    print('AA_EnableHighDpiScaling')
+    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
+
+if hasattr(Qt, 'AA_UseHighDpiPixmaps'):
+    print('AA_UseHighDpiPixmaps')
+    QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
+
+QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
 
 form_class = uic.loadUiType("./form/form.ui")[0]
 


### PR DESCRIPTION
테스트 이미지들입니다.
매번 재부팅하고 테스트했습니다.

## 1920x1080 : 배율 100%
![pass1080p100%](https://user-images.githubusercontent.com/34793045/136943674-e32ec620-5a5d-4033-8ed3-d682c9eddedf.png)

## 1920x1080 : 배율 125%
![pass1080p125%](https://user-images.githubusercontent.com/34793045/136943800-91621cdf-f957-492a-8b42-96c47ed37dfb.png)

## 1920x1080 : 배율 150%
<img width="960" alt="1080p150" src="https://user-images.githubusercontent.com/34793045/136944057-3f814902-11d4-438d-8ad4-de67b84b14fa.png">

## 2560x1600 : 배율 100%
![2560x1600p100%](https://user-images.githubusercontent.com/34793045/136943932-d2f17119-cc0f-41be-8279-69e34780b9e4.png)

## 2560x1600 : 배율 125%
![2560x1600p125%](https://user-images.githubusercontent.com/34793045/136944164-9ac2ea54-f841-4657-88ee-e94c7891da23.png)

## 2560x1600 : 배율 150%
<img width="1280" alt="2560x1600p150%" src="https://user-images.githubusercontent.com/34793045/136944202-ea5027fa-0cde-4c5e-832d-8c2c2ead2749.png">

## 2560x1600 : 배율 200%
![2560x1600p200%](https://user-images.githubusercontent.com/34793045/136946661-348bd1e6-8c63-4671-a968-5c99200fcc1e.png)

Closes #3 