### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pip install pillow==7.2.0; python_version <= '3.5'
-pip install pillow==8.4.0; python_version > '3.5'
-pip install chardet==4.0.0
-pip install pyqt5
+pillow==7.2.0; python_version <= '3.5'
+pillow==8.4.0; python_version > '3.5'
+chardet==4.0.0
+pyqt5


### PR DESCRIPTION
`requirements.txt` 작성하실 때 앞에 `pip install` 은 빼고 적어야
`pip install -r requirements.txt` 했을 때 설치가 가능합니다.

![image](https://user-images.githubusercontent.com/34793045/138216685-9312e402-dcce-40f7-aba8-93db56ea8b22.png)

고친 김에 바로 PR